### PR TITLE
Fix signature of sb-sprof:map-traces for SBCL as of 2.0.10

### DIFF
--- a/core.lisp
+++ b/core.lisp
@@ -75,8 +75,8 @@
 (defun make-graph ()
   (let ((root (make-instance 'node)))
     (sb-sprof:map-traces
-     (lambda (thread time trace)
-       (declare (ignorable thread time))
+     (lambda (thread trace)
+       (declare (ignorable thread))
        (let ((current-node root))
          (sb-sprof:map-trace-samples
           (lambda (info pc-or-offset)


### PR DESCRIPTION
As of [SBCL 2.0.10](http://sbcl.org/all-news.html#2.0.10) the callback to map-traces no longer takes a time argument.